### PR TITLE
Add caption/render option to outgoing files

### DIFF
--- a/lib/threema/send/file.rb
+++ b/lib/threema/send/file.rb
@@ -3,7 +3,7 @@
 require 'threema/send/e2e_upload'
 require 'threema/util'
 require 'json'
-require 'mime/types'
+require 'mimemagic'
 
 class Threema
   class Send
@@ -20,6 +20,7 @@ class Threema
         return content if !params[:thumbnail]
 
         content['t'] = thumbnail_blob_id(params)
+        content['j'] = 1
         content
       end
 
@@ -38,7 +39,7 @@ class Threema
           'm' => params[:mime_type] || @mime_type.to_s || 'application/octet-stream',
           'n' => params[:file_name] || @file_name || 'unknown',
           's' => byte_string.size,
-          'i' => 0
+          'd' => params[:caption] || ''
         }
       end
 
@@ -62,10 +63,7 @@ class Threema
         @file_name = ::File.basename(file)
         return if @file_name.blank?
 
-        extension = ::File.extname(@file_name)
-        return if extension.blank?
-
-        @mime_type = MIME::Types.type_for(extension).first
+        @mime_type = MimeMagic.by_magic(::File.open(file))&.type
       end
     end
   end

--- a/spec/threema/send/file_spec.rb
+++ b/spec/threema/send/file_spec.rb
@@ -111,6 +111,38 @@ RSpec.describe Threema::Send::File do
             box: a_string_matching(/.+/),
           )
         end
+
+        it 'takes a caption' do
+          mock_all
+
+          attributes = attributes_for(:file_message)
+          attributes[:caption] = 'this is a caption for the file I am sending.'
+          instance = described_class.new(attributes)
+
+          payload = instance.payload
+
+          expect(payload).to include(
+            to: a_string_matching(/.+/),
+            nonce: a_string_matching(/.+/),
+            box: a_string_matching(/.+/),
+          )
+        end
+
+        it 'takes a render type' do
+          mock_all
+
+          attributes = attributes_for(:file_message)
+          attributes[:render_type] = :media
+          instance = described_class.new(attributes)
+
+          payload = instance.payload
+
+          expect(payload).to include(
+            to: a_string_matching(/.+/),
+            nonce: a_string_matching(/.+/),
+            box: a_string_matching(/.+/),
+          )
+        end
       end
 
       context 'required payload keys' do

--- a/threema.gemspec
+++ b/threema.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'case_transform'
   spec.add_runtime_dependency 'dotenv'
+  spec.add_runtime_dependency 'mimemagic'
   spec.add_runtime_dependency 'mime-types'
   spec.add_runtime_dependency 'multipart-post'
   spec.add_runtime_dependency 'rbnacl'

--- a/threema.gemspec
+++ b/threema.gemspec
@@ -4,6 +4,7 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'threema/version'
 
+# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
   spec.name          = 'threema'
   spec.version       = Threema::VERSION
@@ -39,3 +40,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Closes #36 

According to [Threema Gateway docs](https://gateway.threema.ch/en/developer/e2e#n:types) on e2e sending:

> Rendering type ('j'):

> 0: Render as a file.
> 1: Render as media (e.g. an image, audio or video).
> 2: Render as a sticker (for transparent images).
> If this field is not set, fall back to the value of 'i'. If no value could be determined or the rendering type is unassigned, assume 0.

This PR does not introduce a way to render the file as a sticker. I'm open to ideas on how the API might look to request the file be rendered as such. For now, I have assumed that if a user passes in a thumbnail it should be displayed as media. If no thumbnail is passes in, it defaults to `0` or rendering as a file.